### PR TITLE
Added MACAD-Gym

### DIFF
--- a/site/data/envs.json
+++ b/site/data/envs.json
@@ -1147,7 +1147,7 @@
             "url": "https://github.com/praveen-palanisamy/macad-gym",
             "short_descr": "MACAD-Gym",
             "long_descr": "Multi-Agent learning environments for various driving scenarios in CARLA AD simulator",
-            "stars": 8,
+            "stars": 11,
             "num_agents": 10,
             "complexity": "medium",
             "tags": [

--- a/site/data/envs.json
+++ b/site/data/envs.json
@@ -1142,6 +1142,24 @@
             ],
             "created_at": "2017-12-15T16:58:37Z"
         },
+		{
+            "name": "Multi-Agent Connected Autonomous Driving Gym",
+            "url": "https://github.com/praveen-palanisamy/macad-gym",
+            "short_descr": "MACAD-Gym",
+            "long_descr": "Multi-Agent learning environments for various driving scenarios in CARLA AD simulator",
+            "stars": 8,
+            "num_agents": 10,
+            "complexity": "medium",
+            "tags": [
+                "Multi-agent",
+				"Autonomous-Driving",
+				"Heterogeneous-agents",
+				"communicating-agents",
+				"Deep-RL-environments",
+                "Competition"
+            ],
+            "created_at": "2019-10-24T28:17:50Z"
+        },
         {
             "name": "Multi-Agent Learning Environments",
             "url": "https://github.com/Bigpig4396/Multi-Agent-Learning-Environments",


### PR DESCRIPTION
MACAD-Gym is a training platform for Multi-Agent Connected Autonomous Driving (MACAD) built on top of the CARLA Autonomous Driving simulator.

MACAD-Gym provides OpenAI Gym-compatible learning environments for various driving scenarios for training Deep RL algorithms in homogeneous/heterogenous, communicating/non-communicating and other multi-agent settings. New environments and scenarios can be easily added using a simple, JSON-like configuration.

Available on PyPI: https://pypi.org/project/macad-gym/